### PR TITLE
feat: implement Google login with Firebase Auth & JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+src/main/resources/*.json
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
 			<artifactId>jjwt-jackson</artifactId>
 			<version>0.12.5</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.firebase</groupId>
+			<artifactId>firebase-admin</artifactId>
+			<version>9.4.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/planify/app/controllers/AuthController.java
+++ b/src/main/java/com/planify/app/controllers/AuthController.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -20,6 +22,12 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<?> registerUser(@RequestBody DtoRegister userDTO) {
         return userService.registerUser(userDTO);
+    }
+
+    @PostMapping("/login/google")
+    public ResponseEntity<?> loginWithGoogle(@RequestBody Map<String, String> request) {
+        String idToken = request.get("idToken");
+        return userService.loginWithGoogle(idToken);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/planify/app/security/FirebaseConfig.java
+++ b/src/main/java/com/planify/app/security/FirebaseConfig.java
@@ -1,0 +1,25 @@
+package com.planify.app.security;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() throws IOException {
+        FileInputStream serviceAccount =
+                new FileInputStream("src/main/resources/planify-f6ab2-firebase-adminsdk-fbsvc-e5ddb58e3b.json"); // Ruta a tu JSON
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+    }
+}


### PR DESCRIPTION
- Add Firebase ID token verification in `loginWithGoogle` method
- Handle user creation/retrieval logic in database:
  - Auto-register user if email doesn't exist
  - Skip password for Google-authenticated users
- Generate JWT token for authenticated users
- Standardize response format with DtoResponse and UserResponseDTO
- Add error handling for invalid tokens (401 status)

Key components:
- FirebaseAuth.getInstance().verifyIdToken() for token validation
- UserRepository integration for user persistence
- JWT generation via jwtGenerador